### PR TITLE
Add benchmark notebook for q filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ python make_filters.py \
 huggingface-cli upload path_to_hf_repo path_to_local_qfilters .
 ```
 
+## Benchmark Q-Filters
+To benchmark the performance of Q-Filters against the standard implementation, follow these steps:
+1. Open the `benchmark_qfilters.ipynb` notebook.
+2. Follow the instructions in the notebook to run the benchmark.
+
 ## Citation
 ```bibtex
 @misc{godey2025qfiltersleveragingqkgeometry,

--- a/benchmark_qfilters.ipynb
+++ b/benchmark_qfilters.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Benchmarking Q-Filters\n",
+    "\n",
+    "This notebook benchmarks the performance of Q-Filters against the standard implementation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup\n",
+    "import torch\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM, TextStreamer\n",
+    "from datasets import load_dataset\n",
+    "from src.hf_cache import QFiltersCache, KNormCache\n",
+    "import time\n",
+    "\n",
+    "model_name = \"deepseek-ai/DeepSeek-R1-Distill-Llama-8B\"\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "streamer = TextStreamer(tokenizer)\n",
+    "\n",
+    "question = \"\"\"What is the probability of two integers selected at random having a greatest common divisor of 1.\"\"\"\n",
+    "input_text = f\"<|User|>{question}<|Assistant|><think>\\n\"\n",
+    "inputs = tokenizer(input_text, return_tensors=\"pt\")\n",
+    "\n",
+    "def benchmark_model(model, past_key_values):\n",
+    "    inputs = tokenizer(input_text, return_tensors=\"pt\").to(model.device)\n",
+    "    start_time = time.time()\n",
+    "    model.generate(\n",
+    "        **inputs,\n",
+    "        do_sample=True,\n",
+    "        temperature=0.5,\n",
+    "        max_new_tokens=4096,\n",
+    "        past_key_values=past_key_values,\n",
+    "        streamer=streamer\n",
+    "    )\n",
+    "    end_time = time.time()\n",
+    "    return end_time - start_time\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load models\n",
+    "standard_model = AutoModelForCausalLM.from_pretrained(\n",
+    "    model_name,\n",
+    "    device_map=\"auto\",\n",
+    "    low_cpu_mem_usage=True,\n",
+    "    torch_dtype=\"bfloat16\"\n",
+    ")\n",
+    "\n",
+    "qfilters_model = AutoModelForCausalLM.from_pretrained(\n",
+    "    model_name,\n",
+    "    device_map=\"auto\",\n",
+    "    low_cpu_mem_usage=True,\n",
+    "    torch_dtype=\"bfloat16\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Benchmark standard implementation\n",
+    "standard_past_key_values = KNormCache(\n",
+    "    window_length=64,\n",
+    "    max_length=128\n",
+    ")\n",
+    "standard_time = benchmark_model(standard_model, standard_past_key_values)\n",
+    "print(f\"Standard implementation time: {standard_time} seconds\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Benchmark Q-Filters implementation\n",
+    "qfilters_past_key_values = QFiltersCache(\n",
+    "    window_length=64,\n",
+    "    max_length=128,\n",
+    "    model_name=model_name\n",
+    ")\n",
+    "qfilters_time = benchmark_model(qfilters_model, qfilters_past_key_values)\n",
+    "print(f\"Q-Filters implementation time: {qfilters_time} seconds\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results\n",
+    "\n",
+    "The benchmark results show the time taken by the standard implementation and the Q-Filters implementation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add a Jupiter notebook for benchmarking Q-Filters.

* Create `benchmark_qfilters.ipynb` to benchmark the performance of Q-Filters against the standard implementation
  - Include setup, data loading, model initialization, and performance comparison sections
  - Compare the standard implementation to an implementation that utilizes Q-Filters

* Update `README.md` to include instructions for running the benchmark notebook

